### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -2,6 +2,8 @@
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-nodejs
 
 name: Node.js CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/HiddenRiverLabs/ts-math-utils/security/code-scanning/1](https://github.com/HiddenRiverLabs/ts-math-utils/security/code-scanning/1)

To fix this problem, you should add an explicit `permissions` block set to `contents: read` either at the root of the workflow file (recommended, applying to all jobs) or at the job (`build`) level. Doing so limits the GITHUB_TOKEN issued to the workflow to only have read access to repository content (source code, etc.), thus minimizing potential risk if some part of the workflow or a dependent action is compromised. Since the workflow only checks out code, installs dependencies, builds, and tests the application, no write access is needed.

**Detailed steps:**
- Add the following lines at the root level of `.github/workflows/node.js.yml`:
  ```yaml
  permissions:
    contents: read
  ```
  This should be placed after the `name:` key, before `on:`.

This change does not require any imports, methods, or definitions—only the addition of the block as described above.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
