### PR TITLE
Potential fix for code scanning alert no. 2: DOM text reinterpreted as HTML

### DIFF
--- a/coverage/lcov-report/sorter.js
+++ b/coverage/lcov-report/sorter.js
@@ -75,6 +75,16 @@ var addSorting = (function() {
     }
     // attaches a data attribute to every tr element with an object
     // of data values keyed by column name
+    // Escape HTML markup in a string
+    function escapeHTML(str) {
+        return String(str)
+            .replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;')
+            .replace(/"/g, '&quot;')
+            .replace(/'/g, '&#39;');
+    }
+
     function loadRowData(tableRow) {
         var tableCols = tableRow.querySelectorAll('td'),
             colNode,
@@ -88,6 +98,8 @@ var addSorting = (function() {
             val = colNode.getAttribute('data-value');
             if (col.type === 'number') {
                 val = Number(val);
+            } else if (typeof val === 'string' && val !== null) {
+                val = escapeHTML(val);
             }
             data[col.key] = val;
         }


### PR DESCRIPTION
Potential fix for [https://github.com/HiddenRiverLabs/ts-math-utils/security/code-scanning/2](https://github.com/HiddenRiverLabs/ts-math-utils/security/code-scanning/2)

The best way to prevent DOM text from being reinterpreted as HTML is to ensure that any value extracted from the DOM (such as via `getAttribute('data-value')`) is properly escaped/encoded before ever being inserted as HTML or used in any rendering context that might be interpreted as HTML. In this specific file, the likely use of the `data` property is for sorting and computational logic, which is fine. However, a belt-and-braces fix is to sanitize the value as soon as it is extracted (especially if it might be used in a UI context elsewhere).

To accomplish this, the value read from `data-value` should be treated as text, and should be either stored safely or escaped. If the code later uses these values for display, it must ensure they are contextually encoded or inserted as plain text (e.g., using `textContent` rather than `innerHTML`). The existing snippet does not show any code that writes these data values back to the DOM, so as a minimum, we can proactively sanitize the `val` values in `loadRowData`. A good general fix is to escape HTML entities from `val` at the point it is read, unless it is a number (as numbers are safe).

Only one file/region needs to be updated: coverage/lcov-report/sorter.js, at the point where column data is extracted and added to the row data object. If we add a robust `escapeHTML` function (or use a well-known one-liner), and apply it to string-type (non-number) data, that will be sufficient.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
